### PR TITLE
fix: prevent extra scrolling with arrow keys

### DIFF
--- a/src/components/ItemWrapper.tsx
+++ b/src/components/ItemWrapper.tsx
@@ -89,8 +89,10 @@ class ItemWrapper extends React.Component<Props> {
     const key = keycode(e.which)
 
     if (key === 'up' || key === 'page up') {
+      e.preventDefault()
       onFocusShift('backwards', id)
     } else if (key === 'down' || key === 'page down') {
+      e.preventDefault()
       onFocusShift('forwards', id)
     } else if (key === 'home') {
       onFocusShift('start', id)


### PR DESCRIPTION
The browser still ensures that the focused element is in the viewport. This patch simply removes the additional scroll associated with <kbd>up</kbd>, <kbd>down</kbd>, <kbd>page up</kbd>, and <kbd>page down</kbd>