### PR TITLE
chore: Add npm registry configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
This patch creates an `.npmrc` which will prevent us from accidentally installing dependencies from Deque's private registry ("Agora").

See #76 & #77